### PR TITLE
Add use method to merge router instances

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -61,6 +61,15 @@ export class Router {
   patch(pathname: string, handler: CallbackHandler) {
     this.add(METHODS.PATCH, pathname, handler);
   }
+  
+  use(router: Router) {
+    for (const m in METHODS) {
+      this.routes[METHODS[m]] = [
+        ...this.routes[METHODS[m]],
+        ...router.routes[METHODS[m]],
+      ];
+    }
+  }
 
   async route(req: Request): Promise<Response> {
     for (const r of this.routes[req.method]) {


### PR DESCRIPTION
Enable merging additional router instances that are defined in other modules

Example:
```
const routerA = new Router();
routerA.post('/hello', async (r: Request, p: Record<string, string>) => {
  return new Response('Hello from / handler');
});

const routerB = new Router();
routerB.post('/bye', async (r: Request, p: Record<string, string>) => {
  return new Response('bye from / handler');
});

const routerC = new Router();

routerC.get('/', async (r: Request, p: Record<string, string>) => {
  return new Response('ok');
});
const router = new Router();

router.use(routerA);
router.use(routerB);
router.use(routerC);

serve(async (r) => await router.route(r), { port: 4000 });
```